### PR TITLE
chore: adds `types` entry in entryp point export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jam.dev/sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The Jam SDK! Supercharge your bug reports.",
   "homepage": "https://jam.dev/docs/product-features/dev-tools/jam.metadata",
   "repository": {
@@ -28,7 +28,8 @@
   "exports": {
     ".": {
       "import": "./dist/jamsdk.js",
-      "require": "./dist/jamsdk.umd.cjs"
+      "require": "./dist/jamsdk.umd.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
For TypeScript projects that use Node.js' conditional exports module resolution heuristic, there needs to be either a `"default"` or `"types"` entry under an exported path.

https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports