### PR TITLE
chore: re-organizes workflows

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -4,15 +4,79 @@ on:
   pull_request:
     types: [closed]
     branches:
-      # runs on main PRs targeting main
       - main
 
 permissions:
   contents: write 
 
 jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.15"
+          cache: "yarn"
+
+      - name: Install
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Build
+        run: yarn build
+
+      - name: Lint
+        run: yarn lint
+
+  deploy-github-pages:
+    runs-on: ubuntu-latest
+    needs: build-and-lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.15"
+          cache: "yarn"
+
+      # Build base package, so links work
+      - name: Install
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Build
+        run: yarn build
+
+      # For the mobx example
+      - name: Install
+        run: yarn install --frozen-lockfile --non-interactive
+        working-directory: ./docs/todo-mobx-example
+
+      - name: Build
+        run: yarn build
+        working-directory: ./docs/todo-mobx-example
+
+      - name: Copy output
+        run: mv docs/todo-mobx-example/dist docs/public && mv docs/public/dist docs/public/todo-mobx-example
+      # End mobx example
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/public
+
   publish:
     if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release-major') || contains(github.event.pull_request.labels.*.name, 'release-minor') || contains(github.event.pull_request.labels.*.name, 'release-patch'))
+    needs: build-and-lint
     runs-on: ubuntu-latest
     steps:
       - name: Determine version type from label
@@ -48,7 +112,7 @@ jobs:
 
       - name: Configure git author
         run: |
-          git config user.name github-actions
+          git config user.name GitHub Actions
           git config user.email github-actions@github.com
 
       - name: Setup Node

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,9 +1,8 @@
-name: Test and Release
+name: Validate PR changes 
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
 
 jobs:
   build-and-lint:
@@ -28,44 +27,3 @@ jobs:
 
       - name: Lint
         run: yarn lint
-
-  deploy-github-pages:
-    runs-on: ubuntu-latest
-    needs: build-and-lint
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18.15"
-          cache: "yarn"
-
-      # Build base package, so links work
-      - name: Install
-        run: yarn install --frozen-lockfile --non-interactive
-
-      - name: Build
-        run: yarn build
-
-      # For the mobx example
-      - name: Install
-        run: yarn install --frozen-lockfile --non-interactive
-        working-directory: ./docs/todo-mobx-example
-
-      - name: Build
-        run: yarn build
-        working-directory: ./docs/todo-mobx-example
-
-      - name: Copy output
-        run: mv docs/todo-mobx-example/dist docs/public && mv docs/public/dist docs/public/todo-mobx-example
-      # End mobx example
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/public


### PR DESCRIPTION
Introduces
1. Validate PR changes: That runs Build and Lint on every PR
2. Publish changes: That runs on every merged PR to main