### PR TITLE
chore: realign version to 1.0.0 (next release publishes 1.0.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jam.dev/sdk",
-  "version": "0.0.7",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jam.dev/sdk",
-      "version": "0.0.7",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.4.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jam.dev/sdk",
-  "version": "0.0.7",
+  "version": "1.0.0",
   "description": "The Jam SDK! Supercharge your bug reports.",
   "homepage": "https://jam.dev/docs/custom-logs",
   "repository": {


### PR DESCRIPTION
## Why

The npm `@jam.dev/sdk` package has a **stranded `1.0.0`** (published 2025-04-11) sitting above the active `0.0.x` line. npm refuses to *implicitly* move the `latest` dist-tag backward from `1.0.0` to any `0.0.x` version, which is why the last publish failed:

> `npm error Cannot implicitly apply the "latest" tag because previously published version 1.0.0 is higher than the new version 0.0.7`

## What

Set the version to `1.0.0`. On merge, the `release-patch` label drives `npm version patch` → **`1.0.1`**, which is higher than the stranded `1.0.0` and therefore cleanly takes `latest` — no `--tag` workaround needed.

## On merge this will
1. Bump `main` to `1.0.1`, push the commit + tag `v1.0.1` (the release bot now bypasses the new branch ruleset)
2. Create GitHub Release `v1.0.1`
3. `npm publish` `1.0.1` → becomes `latest`

Orphan `v0.0.7` tag + GitHub Release (from the prior failed publish, never on npm) have been cleaned up.